### PR TITLE
Implement a dynamically reconfigurable semaphore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/cockroachdb/fifo
+
+go 1.20
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/invariants_off.go
+++ b/invariants_off.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build !fifo_invariants
+
+package fifo
+
+// invariants is false if we were not built with the "fifo_invariants" build
+// tag.
+const invariants = false

--- a/invariants_on.go
+++ b/invariants_on.go
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build fifo_invariants
+
+package fifo
+
+// invariants is true if we were built with the "fifo_invariants" build tag.
+const invariants = true

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,158 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fifo
+
+import "sync"
+
+// Queue implements an allocation efficient FIFO queue. It is not safe for
+// concurrent access.
+//
+// -- Implementation --
+//
+// The queue is implemented as a linked list of nodes, where each node is a
+// small ring buffer. The nodes are allocated using a sync.Pool (a single pool
+// is created for any given type and is used for all queues of that type).
+type Queue[T any] struct {
+	len        int
+	head, tail *queueNode[T]
+
+	pool *queueBackingPool[T]
+}
+
+// MakeQueue constructs a new Queue.
+func MakeQueue[T any]() Queue[T] {
+	return Queue[T]{
+		pool: getQueueBackingPool[T](),
+	}
+}
+
+// Len returns the current length of the queue.
+func (q *Queue[T]) Len() int {
+	return q.len
+}
+
+// PushBack adds t to the end of the queue.
+// The returned pointer can be used to modify the element while it is in the
+// queue; it is valid until the element is removed from the queue.
+func (q *Queue[T]) PushBack(t T) *T {
+	if q.head == nil {
+		q.head = q.pool.get()
+		q.tail = q.head
+	} else if q.tail.IsFull() {
+		newTail := q.pool.get()
+		q.tail.next = newTail
+		q.tail = newTail
+	}
+	q.len++
+	return q.tail.PushBack(t)
+}
+
+// PeekFront returns the current head of the queue, or nil if the queue is
+// empty.
+//
+// The result is only valid until the next call to PopFront.
+func (q *Queue[T]) PeekFront() *T {
+	if q.len == 0 {
+		return nil
+	}
+	return q.head.PeekFront()
+}
+
+// PopFront removes the current head of the queue.
+//
+// It is illegal to call PopFront on an empty queue.
+func (q *Queue[T]) PopFront() {
+	q.head.PopFront()
+	// If this is the only node, we don't want to release it; otherwise we would
+	// allocate/free a node every time we transition between the queue being empty
+	// and non-empty.
+	if q.head.len == 0 && q.head.next != nil {
+		oldHead := q.head
+		q.head = oldHead.next
+		q.pool.put(oldHead)
+	}
+	q.len--
+}
+
+// queueBackingPool is a sync.Pool that used to allocate internal nodes
+// for Queue[T].
+type queueBackingPool[T any] sync.Pool
+
+func newQueueBackingPool[T any]() *queueBackingPool[T] {
+	return &queueBackingPool[T]{
+		New: func() interface{} { return &queueNode[T]{} },
+	}
+}
+
+func (qp *queueBackingPool[T]) get() *queueNode[T] {
+	return (*sync.Pool)(qp).Get().(*queueNode[T])
+}
+
+func (qp *queueBackingPool[T]) put(n *queueNode[T]) {
+	*n = queueNode[T]{}
+	(*sync.Pool)(qp).Put(n)
+}
+
+// queueBackingPools stores singleton queue backing pools, keyed by a nil pointer of the
+// respective type.
+var queueBackingPools sync.Map
+
+func getQueueBackingPool[T any]() *queueBackingPool[T] {
+	p, ok := queueBackingPools.Load((*T)(nil))
+	if !ok {
+		p, _ = queueBackingPools.LoadOrStore((*T)(nil), newQueueBackingPool[T]())
+	}
+	return p.(*queueBackingPool[T])
+}
+
+// We batch the allocation of this many queue objects.
+const queueNodeSize = 8
+
+type queueNode[T any] struct {
+	buf       [queueNodeSize]T
+	head, len int32
+	next      *queueNode[T]
+}
+
+func (qn *queueNode[T]) IsFull() bool {
+	return qn.len == queueNodeSize
+}
+
+func (qn *queueNode[T]) PushBack(t T) *T {
+	if invariants && qn.len >= queueNodeSize {
+		panic("cannot push back into a full node")
+	}
+	i := (qn.head + qn.len) % queueNodeSize
+	qn.buf[i] = t
+	qn.len++
+	return &qn.buf[i]
+}
+
+func (qn *queueNode[T]) PeekFront() *T {
+	return &qn.buf[qn.head]
+}
+
+func (qn *queueNode[T]) PopFront() T {
+	// NB: the notifyQueue never contains an empty ringBuf.
+	if invariants && qn.len == 0 {
+		panic("cannot dequeue from an empty buffer")
+	}
+	t := qn.buf[qn.head]
+	var zero T
+	qn.buf[qn.head] = zero
+	qn.head = (qn.head + 1) % queueNodeSize
+	qn.len--
+	return t
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fifo
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	q := MakeQueue[int]()
+	require.Nil(t, q.PeekFront())
+	require.Equal(t, 0, q.Len())
+	q.PushBack(1)
+	q.PushBack(2)
+	q.PushBack(3)
+	require.Equal(t, 3, q.Len())
+	require.Equal(t, 1, *q.PeekFront())
+	q.PopFront()
+	require.Equal(t, 2, *q.PeekFront())
+	q.PopFront()
+	require.Equal(t, 3, *q.PeekFront())
+	q.PopFront()
+	require.Nil(t, q.PeekFront())
+
+	for i := 1; i <= 1000; i++ {
+		q.PushBack(i)
+		require.Equal(t, i, q.Len())
+	}
+	for i := 1; i <= 1000; i++ {
+		require.Equal(t, i, *q.PeekFront())
+		q.PopFront()
+		require.Equal(t, 1000-i, q.Len())
+	}
+}
+
+func TestQueueRand(t *testing.T) {
+	q := MakeQueue[int]()
+	l, r := 0, 0
+	for iteration := 0; iteration < 100; iteration++ {
+		for n := rand.Intn(100); n > 0; n-- {
+			r++
+			q.PushBack(r)
+			require.Equal(t, r-l, q.Len())
+		}
+		for n := rand.Intn(q.Len() + 1); n > 0; n-- {
+			l++
+			require.Equal(t, l, *q.PeekFront())
+			q.PopFront()
+			require.Equal(t, r-l, q.Len())
+		}
+	}
+}

--- a/semaphore.go
+++ b/semaphore.go
@@ -1,0 +1,237 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fifo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Semaphore implements a weighted, dynamically reconfigurable semaphore which
+// respects context cancellation.
+//
+// The semaphore implements a FIFO policy, where Acquire requests are satisfied
+// in order. This policy provides fairness and prevents starvation but is
+// susceptible to head-of-line blocking, where a large request that can't be
+// satisfied blocks many other small requests that could be.
+type Semaphore struct {
+	mu struct {
+		sync.Mutex
+
+		capacity int64
+		// outstanding can exceed capacity if the capacity is dynamically decreased.
+		outstanding int64
+
+		waiters Queue[semaWaiter]
+
+		// numCanceled is the number of waiters in the waiters queue which have been
+		// canceled. It is used to determine the current number of active waiters in
+		// the queue which is waiters.Len() minus this value.
+		numCanceled int
+
+		// numHadToWait accumulates the total number of Acquire requests which had
+		// to wait because the semaphore was exhausted.
+		numHadToWait int64
+	}
+}
+
+// NewSemaphore creates a new semaphore with the given capacity.
+func NewSemaphore(capacity int64) *Semaphore {
+	if capacity <= 0 {
+		panic("invalid capacity")
+	}
+	s := &Semaphore{}
+	s.mu.capacity = capacity
+	s.mu.waiters = MakeQueue[semaWaiter]()
+	return s
+}
+
+var ErrRequestExceedsCapacity = errors.New("request exceeds semaphore capacity")
+
+// TryAcquire attempts to acquire n units from the semaphore without waiting. On
+// success, returns true and the caller must later Release the units.
+func (s *Semaphore) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.numWaitersLocked() == 0 && s.mu.outstanding+n <= s.mu.capacity {
+		s.mu.outstanding += n
+		return true
+	}
+
+	return false
+}
+
+// Acquire n units from the semaphore, waiting if necessary.
+//
+// If the context is canceled while we are waiting, returns the context error.
+// If n exceeds the current capacity, returns ErrRequestExceedsCapacity.
+// On success, the caller must later Release the units.
+func (s *Semaphore) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+
+	// Fast path.
+	if s.numWaitersLocked() == 0 && s.mu.outstanding+n <= s.mu.capacity {
+		s.mu.outstanding += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.mu.capacity {
+		s.mu.Unlock()
+		return ErrRequestExceedsCapacity
+	}
+
+	c := chanSyncPool.Get().(chan error)
+	defer chanSyncPool.Put(c)
+	w := s.mu.waiters.PushBack(semaWaiter{n: n, c: c})
+	s.mu.numHadToWait++
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		// We need to check if we raced with a channel notify (which happens under
+		// the lock).
+		select {
+		case err := <-c:
+			// We actually fulfilled or failed the request.
+			return err
+		default:
+		}
+		// Mark the request as canceled.
+		w.c = nil
+		s.mu.numCanceled++
+		// If we are the head of the queue, we may be able to fulfill other waiters.
+		s.processWaitersLocked()
+		return ctx.Err()
+
+	case err := <-c:
+		return err
+	}
+}
+
+// Release n units back. These must be units that were acquired by a previous
+// Acquire call. It is legal to split up or coalesce units when releasing.
+func (s *Semaphore) Release(n int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.mu.outstanding -= n
+	if s.mu.outstanding < 0 {
+		panic("releasing more than was acquired")
+	}
+	s.processWaitersLocked()
+}
+
+// UpdateCapacity changes the capacity of the semaphore. If the new capacity is
+// smaller, the already outstanding acquisitions might exceed the new capacity
+// until they are released.
+//
+// If there are Acquire calls that are waiting which are requesting more than
+// the new capacity, they will error out with ErrRequestExceedsCapacity.
+func (s *Semaphore) UpdateCapacity(capacity int64) {
+	if capacity <= 0 {
+		panic("invalid capacity")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.capacity = capacity
+	s.processWaitersLocked()
+}
+
+// Stats returns the current state of the semaphore.
+func (s *Semaphore) Stats() SemaphoreStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SemaphoreStats{
+		Capacity:     s.mu.capacity,
+		Outstanding:  s.mu.outstanding,
+		NumHadToWait: s.mu.numHadToWait,
+	}
+}
+
+// SemaphoreStats contains information about the current state of the semaphore.
+type SemaphoreStats struct {
+	// Capacity is the current capacity of the semaphore.
+	Capacity int64
+	// Outstanding is the number of units that have been acquired. Note that this
+	// can exceed Capacity if the capacity was recently decreased.
+	Outstanding int64
+	// NumHadToWait is the total number of Acquire calls (since the semaphore was
+	// created) that had to wait because the semaphore was exhausted. Useful for
+	// cumulative metrics.
+	NumHadToWait int64
+
+	// TODO(radu): consider keeping track of the total amount of time the
+	// semaphore was exhausted (i.e. there were waiters queued).
+}
+
+func (ss SemaphoreStats) String() string {
+	return fmt.Sprintf("capacity: %d, outstanding: %d, num-had-to-wait: %d",
+		ss.Capacity, ss.Outstanding, ss.NumHadToWait)
+}
+
+type semaWaiter struct {
+	// n is the amount that the waiter is trying to acquire.
+	n int64
+	// c is the channel on which Acquire is blocked. If the request is canceled,
+	// it is set to nil.
+	c chan error
+}
+
+// numWaitersLocked returns how many requests (that have not been canceled) are
+// waiting in the queue.
+func (s *Semaphore) numWaitersLocked() int {
+	return s.mu.waiters.Len() - s.mu.numCanceled
+}
+
+// processWaitersLocked processes and notifies as many waiters from the head of
+// the queue as possible.
+func (s *Semaphore) processWaitersLocked() {
+	for ; s.mu.waiters.Len() > 0; s.mu.waiters.PopFront() {
+		switch w := s.mu.waiters.PeekFront(); {
+		case w.c == nil:
+			// Request was canceled, we can just clean it up.
+			s.mu.numCanceled--
+			if invariants && s.mu.numCanceled < 0 {
+				panic("negative numCanceled")
+			}
+
+		case s.mu.outstanding+w.n <= s.mu.capacity:
+			// Request can be fulfilled.
+			s.mu.outstanding += w.n
+			w.c <- nil
+
+		case w.n > s.mu.capacity:
+			// Request must be failed. This can happen if the capacity was decreased
+			// while the element was queued.
+			w.c <- ErrRequestExceedsCapacity
+
+		default:
+			// Head of the queue needs to wait some more.
+			return
+		}
+	}
+}
+
+// chanSyncPool is used to pool allocations of the channels used to notify
+// goroutines waiting in Acquire.
+var chanSyncPool = sync.Pool{
+	New: func() interface{} { return make(chan error, 1) },
+}

--- a/semaphore_bench_test.go
+++ b/semaphore_bench_test.go
@@ -1,0 +1,122 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fifo
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// BenchmarkSemaphore runs benchmarks for the semaphore and for a simple channel
+// semaphore as a baseline.
+//
+// Sample results on an Apple M1:
+//
+//	Semaphore/W1/C1/Semaphore-10        66.1ns ± 0%
+//	Semaphore/W1/C1/Channel-10          91.0ns ± 0%
+//	Semaphore/W2/C2/Semaphore-10         119ns ± 3%
+//	Semaphore/W2/C2/Channel-10           123ns ± 7%
+//	Semaphore/W8/C4/Semaphore-10         448ns ± 1%
+//	Semaphore/W8/C4/Channel-10           497ns ± 4%
+//	Semaphore/W128/C4/Semaphore-10       433ns ± 1%
+//	Semaphore/W128/C4/Channel-10         515ns ±25%
+//	Semaphore/W512/C128/Semaphore-10     862ns ±23%
+//	Semaphore/W512/C128/Channel-10      1.54µs ±37%
+//	Semaphore/W512/C513/Semaphore-10     374ns ±59%
+//	Semaphore/W512/C513/Channel-10       376ns ±43%
+//	Semaphore/W512/C511/Semaphore-10     499ns ±58%
+//	Semaphore/W512/C511/Channel-10       316ns ±66%
+//	Semaphore/W1024/C4/Semaphore-10      392ns ± 2%
+//	Semaphore/W1024/C4/Channel-10        517ns ±18%
+//	Semaphore/W1024/C4096/Semaphore-10   437ns ± 2%
+//	Semaphore/W1024/C4096/Channel-10     386ns ±41%
+func BenchmarkSemaphore(b *testing.B) {
+	specs := []struct {
+		workers, capacity int
+	}{
+		{workers: 1, capacity: 1},
+		{workers: 2, capacity: 2},
+		{workers: 8, capacity: 4},
+		{workers: 128, capacity: 4},
+		{workers: 512, capacity: 128},
+		{workers: 512, capacity: 513},
+		{workers: 512, capacity: 511},
+		{workers: 1024, capacity: 4},
+		{workers: 1024, capacity: 4096},
+	}
+	for _, s := range specs {
+		b.Run(fmt.Sprintf("W%d/C%d", s.workers, s.capacity), func(b *testing.B) {
+			b.Run("Semaphore", func(b *testing.B) {
+				benchmarkSemaphore(b, s.capacity, s.workers)
+			})
+			b.Run("Channel", func(b *testing.B) {
+				benchmarkChannelSem(b, s.capacity, s.workers)
+			})
+		})
+	}
+}
+
+func benchmarkSemaphore(b *testing.B, capacity, workers int) {
+	sem := NewSemaphore(int64(capacity))
+	g, ctx := errgroup.WithContext(context.Background())
+	runWorker := func(workerNum int) {
+		g.Go(func() error {
+			for i := workerNum; i < b.N; i += workers {
+				err := sem.Acquire(ctx, 1)
+				if err != nil {
+					return err
+				}
+				runtime.Gosched()
+				sem.Release(1)
+			}
+			return nil
+		})
+	}
+	for i := 0; i < workers; i++ {
+		runWorker(i)
+	}
+	if err := g.Wait(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchmarkChannelSem(b *testing.B, capacity, workers int) {
+	sem := make(chan struct{}, capacity)
+	g, ctx := errgroup.WithContext(context.Background())
+	runWorker := func(workerNum int) {
+		g.Go(func() error {
+			for i := workerNum; i < b.N; i += workers {
+				select {
+				case <-ctx.Done():
+				case sem <- struct{}{}:
+				}
+				runtime.Gosched()
+				<-sem
+			}
+			return nil
+		})
+	}
+	for i := 0; i < workers; i++ {
+		runWorker(i)
+	}
+	if err := g.Wait(); err != nil {
+		b.Fatal(err)
+	}
+	close(sem)
+}

--- a/semaphore_test.go
+++ b/semaphore_test.go
@@ -1,0 +1,266 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fifo
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemaphoreAPI(t *testing.T) {
+	s := NewSemaphore(10)
+	require.True(t, s.TryAcquire(5))
+	require.False(t, s.TryAcquire(10))
+	require.Error(t, ErrRequestExceedsCapacity, s.Acquire(context.Background(), 20))
+	require.Equal(t, "capacity: 10, outstanding: 5, num-had-to-wait: 0", s.Stats().String())
+
+	ch := make(chan struct{}, 10)
+	go func() {
+		require.NoError(t, s.Acquire(context.Background(), 8))
+		ch <- struct{}{}
+		require.NoError(t, s.Acquire(context.Background(), 1))
+		ch <- struct{}{}
+		require.NoError(t, s.Acquire(context.Background(), 5))
+		ch <- struct{}{}
+	}()
+	assertNoRecv(t, ch)
+	s.Release(5)
+	assertRecv(t, ch)
+	assertRecv(t, ch)
+	assertNoRecv(t, ch)
+	s.Release(1)
+	assertNoRecv(t, ch)
+	s.Release(8)
+	assertRecv(t, ch)
+
+	// Test UpdateCapacity.
+	go func() {
+		require.NoError(t, s.Acquire(context.Background(), 8))
+		ch <- struct{}{}
+		require.NoError(t, s.Acquire(context.Background(), 1))
+		ch <- struct{}{}
+		require.Error(t, ErrRequestExceedsCapacity, s.Acquire(context.Background(), 5))
+		ch <- struct{}{}
+	}()
+	assertNoRecv(t, ch)
+	s.UpdateCapacity(15)
+	assertRecv(t, ch)
+	assertRecv(t, ch)
+	assertNoRecv(t, ch)
+	s.UpdateCapacity(2)
+	assertRecv(t, ch)
+}
+
+// TestSemaphoreBasic is a test with multiple goroutines acquiring a unit and
+// releasing it right after.
+func TestSemaphoreBasic(t *testing.T) {
+	capacities := []int64{1, 5, 10, 50, 100}
+	goroutineCounts := []int{1, 10, 100}
+
+	for _, capacity := range capacities {
+		for _, numGoroutines := range goroutineCounts {
+			s := NewSemaphore(capacity)
+			ctx := context.Background()
+			resCh := make(chan error, numGoroutines)
+
+			for i := 0; i < numGoroutines; i++ {
+				go func() {
+					err := s.Acquire(ctx, 1)
+					if err != nil {
+						resCh <- err
+						return
+					}
+					s.Release(1)
+					resCh <- nil
+				}()
+			}
+
+			for i := 0; i < numGoroutines; i++ {
+				if err := assertRecv(t, resCh); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if stats := s.Stats(); stats.Outstanding != 0 {
+				t.Fatalf("expected nothing outstanding; got %s", stats)
+			}
+		}
+	}
+}
+
+// TestSemaphoreContextCancellation tests the behavior that for an ongoing
+// blocked acquisition, if the context passed in gets canceled the acquisition
+// gets canceled too with an error indicating so.
+func TestSemaphoreContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := NewSemaphore(1)
+	require.NoError(t, s.Acquire(ctx, 1))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Acquire(ctx, 1)
+	}()
+
+	cancel()
+
+	err := assertRecv(t, errCh)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation error, got %v", err)
+	}
+
+	stats := s.Stats()
+	assert.Equal(t, int64(1), stats.Capacity)
+	assert.Equal(t, int64(1), stats.Outstanding)
+}
+
+// TestSemaphoreCanceledAcquisitions tests the behavior where we enqueue
+// multiple acquisitions with canceled contexts and expect any subsequent
+// acquisition with a valid context to proceed without error.
+func TestSemaphoreCanceledAcquisitions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := NewSemaphore(1)
+	require.NoError(t, s.Acquire(ctx, 1))
+
+	cancel()
+	const numGoroutines = 5
+
+	errCh := make(chan error)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			errCh <- s.Acquire(ctx, 1)
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		if err := assertRecv(t, errCh); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	}
+	s.Release(1)
+
+	go func() {
+		errCh <- s.Acquire(context.Background(), 1)
+	}()
+
+	require.NoError(t, assertRecv(t, errCh))
+}
+
+// TestSemaphoreNumHadToWait checks Stats().NumHadToWait.
+func TestSemaphoreNumHadToWait(t *testing.T) {
+	s := NewSemaphore(1)
+	ctx := context.Background()
+	doneCh := make(chan struct{}, 10)
+	doAcquire := func(ctx context.Context) {
+		err := s.Acquire(ctx, 1)
+		if ctx.Err() == nil {
+			require.NoError(t, err)
+			doneCh <- struct{}{}
+		}
+	}
+
+	assertNumWaitersSoon := func(exp int64) {
+		for i := 0; ; i++ {
+			got := s.Stats().NumHadToWait
+			if got == exp {
+				return
+			}
+			if i >= 20 {
+				t.Fatalf("expected num-had-to-wait to be %d, got %d", got, exp)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	// Initially s should have no waiters.
+	assert.Equal(t, int64(0), s.Stats().NumHadToWait)
+	require.NoError(t, s.Acquire(ctx, 1))
+	// Still no waiters.
+	assert.Equal(t, int64(0), s.Stats().NumHadToWait)
+	for i := 0; i < 10; i++ {
+		go doAcquire(ctx)
+	}
+	assertNumWaitersSoon(10)
+	s.Release(1)
+	assertRecv(t, doneCh)
+	go doAcquire(ctx)
+	assertNumWaitersSoon(11)
+	for i := 0; i < 10; i++ {
+		s.Release(1)
+		assertRecv(t, doneCh)
+	}
+	assert.Equal(t, int64(11), s.Stats().NumHadToWait)
+}
+
+func TestConcurrentUpdatesAndAcquisitions(t *testing.T) {
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	const maxCap = 100
+	s := NewSemaphore(maxCap)
+	const N = 100
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			newCap := rand.Int63n(maxCap-1) + 1
+			s.UpdateCapacity(newCap)
+		}()
+	}
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runtime.Gosched()
+			n := rand.Int63n(maxCap)
+			err := s.Acquire(ctx, n)
+			runtime.Gosched()
+			if err == nil {
+				s.Release(n)
+			}
+		}()
+	}
+	wg.Wait()
+	s.UpdateCapacity(maxCap)
+	stats := s.Stats()
+	assert.Equal(t, int64(100), stats.Capacity)
+	assert.Equal(t, int64(0), stats.Outstanding)
+}
+
+func assertRecv[T any](t *testing.T, ch chan T) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(time.Second):
+		t.Fatal("did not receive notification")
+		panic("unreachable")
+	}
+}
+
+func assertNoRecv[T any](t *testing.T, ch chan T) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("received unexpected notification")
+	case <-time.After(10 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
This repository is intended to provide some primitives similar to the ones in the `quotapool` package in Cockroach, but in a standalone repository where Pebble can also use them.

#### add Queue

This commit adds a FIFO queue implementation which is based on
`cockroachdb/pkg/util/quotapool.notifyQueue`. Most of the code is
copied from `notifyQueue` and modified a bit.

#### add Semaphore

This commit adds a semaphore with dynamically configurable capacity.
It is a simplified version of
`cockroachdb/pkg/util/quotapool.IntPool`.

The implementation is based on `quotapool` (and to a lesser extent
`x/sync/semaphore`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/fifo/1)
<!-- Reviewable:end -->
