### PR TITLE
queue: make queue pools safer

### DIFF
--- a/queue_test.go
+++ b/queue_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var pool = MakeQueueBackingPool[int]()
+
 func TestQueue(t *testing.T) {
-	q := MakeQueue[int]()
+	q := MakeQueue[int](&pool)
 	require.Nil(t, q.PeekFront())
 	require.Equal(t, 0, q.Len())
 	q.PushBack(1)
@@ -49,7 +51,7 @@ func TestQueue(t *testing.T) {
 }
 
 func TestQueueRand(t *testing.T) {
-	q := MakeQueue[int]()
+	q := MakeQueue[int](&pool)
 	l, r := 0, 0
 	for iteration := 0; iteration < 100; iteration++ {
 		for n := rand.Intn(100); n > 0; n-- {

--- a/semaphore.go
+++ b/semaphore.go
@@ -56,9 +56,11 @@ func NewSemaphore(capacity int64) *Semaphore {
 	}
 	s := &Semaphore{}
 	s.mu.capacity = capacity
-	s.mu.waiters = MakeQueue[semaWaiter]()
+	s.mu.waiters = MakeQueue[semaWaiter](&semaQueuePool)
 	return s
 }
+
+var semaQueuePool = MakeQueueBackingPool[semaWaiter]()
 
 var ErrRequestExceedsCapacity = errors.New("request exceeds semaphore capacity")
 


### PR DESCRIPTION
The automatic sharing of queue pools, together with the queue API returning `*T` pointers can lead to code inadvertently or maliciously reading from/writing into the values from another queue (even from a separate package, if the type T is exported).

We remove the singleton map and require the caller to pass a pool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/fifo/3)
<!-- Reviewable:end -->
